### PR TITLE
Avoid re-appending

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-append-sourcemapping",
     "description": "Grunt task to append a JavaScript sourcemapping URL comment",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "author": {
         "name": "James Allardice",
         "email": "admin@jamesallardice.com"

--- a/tasks/append-sourcemapping.js
+++ b/tasks/append-sourcemapping.js
@@ -9,7 +9,14 @@ module.exports = function (grunt) {
         var done = this.async(),
             files = this.data.files;
         async.forEach(Object.keys(files), function (file, callback) {
-            fs.appendFile(file, "/*\n//@ sourceMappingURL=" + files[file] + "\n*/", callback);
+            fs.readFile(file, function(err, data) {
+                if (err) {throw err;}
+                if(!data.toString().match(/\/\/@ sourceMappingURL=[^\n]*\n\*\/$/)) {
+                    fs.appendFile(file, "/*\n//@ sourceMappingURL=" + files[file] + "\n*/", callback);
+                } else {
+                    callback.call(this);
+                }
+            });
         }.bind(this), done);
     });
 


### PR DESCRIPTION
Avoid appending the sourcemapping URL comment more than once.

Read the targeted JS file and, if the mentioned comment is already
present, it
is not appended again. Check the existance of the comment using a
regexp.
